### PR TITLE
Upgrade sidekiq version and fix ParameterFilter deprecation warning

### DIFF
--- a/app/models/async_request/job.rb
+++ b/app/models/async_request/job.rb
@@ -37,7 +37,7 @@ module AsyncRequest
     end
 
     def filtered_params(params)
-      ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
+      ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
                                            .filter(params.compact)
                                            .inspect
     end

--- a/async_request.gemspec
+++ b/async_request.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", ">= 4.2"
-  s.add_dependency 'sidekiq', '>= 4.0', '< 6'
+  s.add_dependency 'sidekiq', '>= 4.0', '< 7'
 
   s.add_development_dependency "pg"
   s.add_development_dependency "pry"

--- a/lib/async_request/version.rb
+++ b/lib/async_request/version.rb
@@ -1,3 +1,3 @@
 module AsyncRequest
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.0.10'.freeze
 end

--- a/lib/async_request/version.rb
+++ b/lib/async_request/version.rb
@@ -1,3 +1,3 @@
 module AsyncRequest
-  VERSION = '0.0.9'.freeze
+  VERSION = '0.1.0'.freeze
 end


### PR DESCRIPTION
- Update Sidekiq dependency up to version 6
- Fix ParameterFilter deprecation warning